### PR TITLE
Add log level settings

### DIFF
--- a/.env
+++ b/.env
@@ -15,3 +15,7 @@ EMBEDDING_DIM=384
 INGEST_CHUNK_SIZE=1000
 INGEST_CHUNK_OVERLAP=200
 ALLOWED_FILE_EXTENSIONS=["txt","pdf","docx","csv","xlsx","json"]
+
+# ─────────── Logging ───────────
+LOG_LEVEL=INFO
+LOG_DIR=logs

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -1,6 +1,6 @@
 # app/core/config.py
 from pydantic_settings import BaseSettings
-from typing import List
+from typing import List, Optional
 
 class Settings(BaseSettings):
     # Milvus configuration
@@ -18,6 +18,10 @@ class Settings(BaseSettings):
     INGEST_CHUNK_SIZE: int
     INGEST_CHUNK_OVERLAP: int
     ALLOWED_FILE_EXTENSIONS: List[str]
+
+    # Logging
+    LOG_LEVEL: str = "INFO"
+    LOG_DIR: Optional[str] = "logs"
 
     class Config:
         env_file = ".env"

--- a/src/core/logger.py
+++ b/src/core/logger.py
@@ -5,7 +5,7 @@ from logging.handlers import RotatingFileHandler
 from src.core.config import settings
 
 # Ensure log directory exists
-log_dir = settings.LOG_DIR if hasattr(settings, 'LOG_DIR') else 'logs'
+log_dir = settings.LOG_DIR or 'logs'
 os.makedirs(log_dir, exist_ok=True)
 
 # Log file path

--- a/src/main.py
+++ b/src/main.py
@@ -2,10 +2,12 @@
 
 from fastapi import FastAPI
 from src.api.routes.ingest_router import router as ingest_router
+from src.api.routes import router as health_router
 
 app = FastAPI(title="RAG FastAPI")
 
 app.include_router(ingest_router)
+app.include_router(health_router)
 
 @app.get("/")
 async def read_root():

--- a/src/services/ingestion_service.py
+++ b/src/services/ingestion_service.py
@@ -12,7 +12,10 @@ from docx import Document
 from fastapi import HTTPException, UploadFile
 
 from src.core.config import settings
-from src.services.embeddings import embedding_model, sparse_embedding_model
+# Avoid expensive model loading at import time
+def _get_embedding_models():
+    from src.services.embeddings import embedding_model, sparse_embedding_model
+    return embedding_model, sparse_embedding_model
 from src.db.milvus_client import MilvusClient
 
 logger = logging.getLogger("ingestion")
@@ -92,6 +95,7 @@ def ingest_bytes(data: bytes, filename: str, user_id: str) -> None:
     logger.info(f"Embedding {count} chunks from '{filename}'")
 
     # --- 2) Compute embeddings ---
+    embedding_model, sparse_embedding_model = _get_embedding_models()
     dense_vecs = embedding_model.encode(list(texts), show_progress_bar=False).tolist()
     sparse_mat = sparse_embedding_model.encode_documents(list(texts))
 


### PR DESCRIPTION
## Summary
- extend settings with `LOG_LEVEL` and `LOG_DIR`
- default log settings in `.env`
- configure logger to use new fields
- avoid heavy model loading during import
- register health router

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68835841ce64832e9525524eaa053ebb