### PR TITLE
Add base router to FastAPI app

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,10 +1,12 @@
 # src/main.py
 
 from fastapi import FastAPI
+from src.api.routes import router
 from src.api.routes.ingest_router import router as ingest_router
 
 app = FastAPI(title="RAG FastAPI")
 
+app.include_router(router)
 app.include_router(ingest_router)
 
 @app.get("/")


### PR DESCRIPTION
## Summary
- import the router defined in `src/api/routes`
- register it in `src/main.py` before other routers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883583e7420832e93d513254cfaa1ba