### PR TITLE
Add extensive logging across FastAPI project

### DIFF
--- a/src/api/routes/__init__.py
+++ b/src/api/routes/__init__.py
@@ -1,7 +1,11 @@
 from fastapi import APIRouter
+import logging
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
 @router.get('/health')
 def health_check():
+    logger.debug("Health check endpoint called")
     return {'status': 'ok'}

--- a/src/api/routes/search_router.py
+++ b/src/api/routes/search_router.py
@@ -1,6 +1,10 @@
 from fastapi import APIRouter, Query, HTTPException
 from typing import List, Optional
+import logging
+
 from src.services.search_service import SearchService
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/search", tags=["search"])
 service = SearchService()
@@ -15,7 +19,10 @@ async def search_endpoint(
     Perform a hybrid search with BM25, dense & sparse vectors, and optional reranking.
     """
     try:
+        logger.info("Search requested: '%s' top_k=%s expr=%s", q, top_k, expr)
         results = service.search(q, top_k, expr)
+        logger.info("Search returned %d results", len(results))
         return {"query": q, "results": results}
     except Exception as e:
+        logger.error("Search failed for query '%s': %s", q, e)
         raise HTTPException(status_code=500, detail=str(e))

--- a/src/db/milvus_client.py
+++ b/src/db/milvus_client.py
@@ -17,10 +17,12 @@ class MilvusClient:
         with cls._lock:
             if cls._instance is None:
                 cls._instance = super().__new__(cls)
+                _logger.debug("Initializing Milvus client")
                 cls._instance._connect()
             return cls._instance
 
     def _connect(self):
+        _logger.debug("Connecting to Milvus")
         connections.connect(
             alias="default",
             host=settings.MILVUS_HOST,
@@ -31,6 +33,7 @@ class MilvusClient:
 
     def get_collection(self, name: str | None = None) -> Collection:
         name = name or settings.MILVUS_COLLECTION_NAME
+        _logger.debug("Retrieving collection %s", name)
 
         if not utility.has_collection(name):
             _logger.info(f"🚀 Creating Milvus collection '{name}'")

--- a/src/main.py
+++ b/src/main.py
@@ -1,10 +1,15 @@
 # src/main.py
 
 from fastapi import FastAPI
+import src.core.logger  # configure root logger on import
+import logging
+
 from src.api.routes import router
 from src.api.routes import router as health_router
 from src.api.routes.ingest_router import router as ingest_router
 from src.api.routes.search_router import router as search_router
+
+logger = logging.getLogger(__name__)
 
 app = FastAPI(title="RAG FastAPI")
 
@@ -15,4 +20,5 @@ app.include_router(search_router)
 
 @app.get("/")
 async def read_root():
+    logger.info("Root endpoint called")
     return {"message": "Welcome to the RAG FastAPI"}


### PR DESCRIPTION
## Summary
- configure logging in `main.py`
- log health route and ingestion routes
- add logging to search route
- include detailed debug logs for Milvus client, ingestion service, and search service

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68870be418e0832e80275d1678171f2b